### PR TITLE
Player death returns the flag if they were carrying it.

### DIFF
--- a/Code4.lua
+++ b/Code4.lua
@@ -405,8 +405,21 @@ function player_respawn(data)
 	-- Check which team the player is on and set moveTo to their spawn.
     if isPlayerOnBlueTeam(targetPlayer.name) then
 		moveTo = blueSpawnPoint;
+		
+		if targetPlayer:hasItemWithName('Green Flag') then
+			greenFlagIsTaken = false;	
+			a_broadcast_npc(Overlord, targetPlayer.name .. " has died with the &aGreen Flag&f!");
+			soundblock:playSound('LAVA_POP', 1000, 50);
+		end
+		
       elseif isPlayerOnGreenTeam(targetPlayer.name) then
 		moveTo = greenSpawnPoint;
+		
+		if targetPlayer:hasItemWithName('Blue Flag') then
+			blueFlagIsTaken = false;
+			a_broadcast_npc(Overlord, targetPlayer.name .. " has died with the &9Blue Flag&f!");
+			soundblock:playSound('LAVA_POP', 1000, 50);
+		end
     end
 	
 	if moveTo ~= nil then


### PR DESCRIPTION
When a player dies while carrying the other teams flag, it gets returned. I've left in the code that handles dropping/picking up flags off the ground in-case players decide to manually throw the flag somehow to allow team-mates to pick it up.
